### PR TITLE
Update by-sa.markdown: close bold markdown

### DIFF
--- a/4.0/by-sa.markdown
+++ b/4.0/by-sa.markdown
@@ -64,7 +64,7 @@ a. ___License grant.___
 
        A. __Offer from the Licensor – Licensed Material.__ Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
 
-       B. __Additional offer from the Licensor – Adapted Material. Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+       B. __Additional offer from the Licensor – Adapted Material.__ Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
 
        C. __No downstream restrictions.__ You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
 


### PR DESCRIPTION
missing "__" after "B. __Additional offer from the Licensor – Adapted Material."

noticed this in 2015 but forgot to make a PR, surprised it was still here all along!