### PR TITLE
Added link and full stop in last sentence in BY-NC-ND

### DIFF
--- a/4.0/by-nc-nd.markdown
+++ b/4.0/by-nc-nd.markdown
@@ -156,4 +156,4 @@ d. Nothing in this Public License constitutes or may be interpreted as a limitat
 
 > Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at [creativecommons.org/policies](http://creativecommons.org/policies), Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
 >
-> Creative Commons may be contacted at creativecommons.org
+> Creative Commons may be contacted at [creativecommons.org](http://creativecommons.org).


### PR DESCRIPTION
The cretivecommons.org wasn't a link and there wasn't a full stop in the last sentence in the BY-NC-ND 4.0 license.